### PR TITLE
[New API] Create String and StringCursor objects (with read-only methods)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,9 @@ To run all the test packages of the project, execute the following command from 
 
     $ go test ./...
 
+To view code coverage, run the following and open `coverage.html` in your browser.
+
+```sh
+    go test ./... -coverprofile=coverage.out
+    go tool cover -html=coverage.out -o coverage.html
+```

--- a/crdt/ctree.go
+++ b/crdt/ctree.go
@@ -966,7 +966,7 @@ func (t *CausalTree) DeleteCharAt(i int) error {
 // | Operations - Insert str container |
 // +-----------------------------------+
 
-//Inserts a string container as a child of the root atom.
+// Inserts a string container as a child of the root atom.
 type InsertStr struct{}
 
 func (v InsertStr) AtomPriority() int { return insertStrPriority }
@@ -997,7 +997,7 @@ func (t *CausalTree) InsertStr() error {
 // | Operations - Insert Add atom |
 // +------------------------------+
 
-//Inserts an add atom as a child of the atom pointed by cursor.
+// Inserts an add atom as a child of the atom pointed by cursor.
 type InsertAdd struct {
 	//Value inserted into the counter container
 	Value int32
@@ -1010,7 +1010,7 @@ func (v InsertAdd) MarshalJSON() ([]byte, error) {
 
 func (v InsertAdd) String() string { return strconv.FormatInt(int64(v.Value), 10) }
 
-//InsertAdd atoms only accept child of type InsertAdd.
+// InsertAdd atoms only accept child of type InsertAdd.
 func (v InsertAdd) ValidateChild(child AtomValue) error {
 	switch child.(type) {
 	case InsertAdd:
@@ -1042,7 +1042,7 @@ func (t *CausalTree) InsertAddAt(val int32, i int) error {
 // | Operations - Insert counter container |
 // +---------------------------------------+
 
-//Inserts a counter container as a child of the root atom.
+// Inserts a counter container as a child of the root atom.
 type InsertCounter struct{}
 
 func (v InsertCounter) AtomPriority() int { return insertCounterPriority }

--- a/crdt/cursor.go
+++ b/crdt/cursor.go
@@ -5,6 +5,50 @@ import (
 	"unicode"
 )
 
+// Invokes the closure f for each atom of the causal block, including the head and except for Deletes.
+// Returns the number of atoms visited.
+//
+// The closure should return 'false' to cut the traversal short, as in a 'break' statement. Otherwise, return true.
+//
+// The causal block is defined as the contiguous range containing the head and all of its descendents.
+//
+// Time complexity: O(atoms), or, O(avg. block size)
+func walkCausalBlock2(weave []Atom, headPos int, f func(pos int, atom Atom, isDeleted bool) bool) int {
+	block := weave[headPos:]
+	if len(block) == 0 {
+		return 0
+	}
+	head := block[0]
+	i := 0
+	count := 1
+	for i < len(block) {
+		atom := block[i]
+		if i > 0 && atom.Cause.Timestamp < head.ID.Timestamp {
+			// First atom whose parent has a lower timestamp (older) than head is the
+			// end of the causal block.
+			break
+		}
+		pos := headPos + i
+		// Checks if current atom is deleted.
+		isDeleted := false
+		for i = i + 1; i < len(block); i++ {
+			if _, ok := block[i].Value.(Delete); ok {
+				isDeleted = true
+			} else {
+				break
+			}
+		}
+		// Invokes closure, exiting if it returns false.
+		if !f(pos, atom, isDeleted) {
+			break
+		}
+		count++
+	}
+	return count
+}
+
+// ----
+
 // Value represents a structure that may be converted to concrete data.
 //
 // Each concrete type has a Snapshot() method with appropriate return type.
@@ -33,31 +77,9 @@ func (p *treePosition) atomIndex() int {
 	panic(fmt.Sprintf("atomID %v not found after position %d (weave size: %d)", p.atomID, p.lastKnownPos, size))
 }
 
-func (p *treePosition) walk(onDeletePos, onDelete, onAtom func(j int, atom Atom) bool) {
-	i := p.atomIndex()
-
-	isDeleting := false
-	j := i
-	walkCausalBlock(p.t.Weave[i:], func(atom Atom) bool {
-		j++
-		switch atom.Value.(type) {
-		case Delete:
-			if atom.Cause == p.atomID {
-				// Position itself is deleted, maybe interrupt iteration.
-				return onDeletePos(j, atom)
-			}
-			// Any atom may have multiple consecutive Delete children, so we call onDelete only
-			// once, when isDeleting=false.
-			if !isDeleting {
-				isDeleting = true
-				return onDelete(j, atom)
-			}
-			return true
-		default:
-			isDeleting = false
-			return onAtom(j, atom)
-		}
-	})
+func (p *treePosition) walk(f func(pos int, atom Atom, isDeleted bool) bool) {
+	headPos := p.atomIndex()
+	walkCausalBlock2(p.t.Weave, headPos, f)
 }
 
 // ---- String value
@@ -67,47 +89,55 @@ type String struct{ treePosition }
 
 func (*String) isValue() {}
 
-func (s *String) walk(onDeleteChar, onInsertChar func(atom Atom)) {
-	onDeletePos := func(j int, atom Atom) bool { return true }
-	onDelete := func(j int, atom Atom) bool {
-		onDeleteChar(atom)
+func (s *String) walkChars(f func(i int, atom Atom, isDeleted bool) bool) {
+	s.walk(func(pos int, atom Atom, isDeleted bool) bool {
+		switch atom.Value.(type) {
+		case InsertStr:
+			return !isDeleted
+		case InsertChar:
+			return f(pos, atom, isDeleted)
+		default:
+			panic(fmt.Sprintf("unexpected atom type in String: %T", atom.Value))
+		}
+	})
+}
+
+// IsDeleted returns whether the string has been deleted.
+func (s *String) IsDeleted() bool {
+	i := s.atomIndex()
+	weave := s.t.Weave
+	if i+1 >= len(weave) {
+		return false
+	}
+	if _, ok := weave[i+1].Value.(Delete); ok {
 		return true
 	}
-	onAtom := func(j int, atom Atom) bool {
-		switch atom.Value.(type) {
-		case InsertChar:
-			onInsertChar(atom)
-			return true
-		default:
-			panic(fmt.Sprintf("Invalid atom value for string: %T", atom.Value))
-		}
-	}
-	s.treePosition.walk(onDeletePos, onDelete, onAtom)
+	return false
 }
 
 // Snapshot returns the string represented by the atom.
+// Returns the empty string if string was deleted.
 func (s *String) Snapshot() string {
 	var chars []rune
-	onDeleteChar := func(atom Atom) {
-		chars = chars[:len(chars)-1]
-	}
-	onInsertChar := func(atom Atom) {
-		chars = append(chars, atom.Value.(InsertChar).Char)
-	}
-	s.walk(onDeleteChar, onInsertChar)
+	s.walkChars(func(pos int, atom Atom, isDeleted bool) bool {
+		if !isDeleted {
+			chars = append(chars, atom.Value.(InsertChar).Char)
+		}
+		return true
+	})
 	return string(chars)
 }
 
 // Len returns the size of the string (in codepoints).
+// Returns 0 if string was deleted.
 func (s *String) Len() int {
 	var size int
-	onDeleteChar := func(atom Atom) {
-		size--
-	}
-	onInsertChar := func(atom Atom) {
-		size++
-	}
-	s.walk(onDeleteChar, onInsertChar)
+	s.walkChars(func(pos int, atom Atom, isDeleted bool) bool {
+		if !isDeleted {
+			size++
+		}
+		return true
+	})
 	return size
 }
 
@@ -153,7 +183,7 @@ func (cur *StringCursor) GetString() *String {
 		}
 	}
 	if headPos < 0 {
-		panic(fmt.Sprintf("Invalid weave"))
+		panic("invalid weave")
 	}
 	return &String{
 		treePosition{
@@ -165,45 +195,39 @@ func (cur *StringCursor) GetString() *String {
 }
 
 // Index moves the cursor to the given string position.
+// Returns an error if index is out of range [-1:Len()-1], or string is deleted.
 func (cur *StringCursor) Index(i int) error {
 	if i < -1 {
-		return fmt.Errorf("Out of bounds")
+		return fmt.Errorf("out of bounds")
 	}
-	// Walk the string forward to find the char at position i.
-	pos := -1
+	s := cur.GetString()
+	if s.IsDeleted() {
+		return fmt.Errorf("string is deleted")
+	}
+	// Walk the string starting from head to find the char at position i.
+	indexPos := -1
 	var count int
-	onDeletePos := func(j int, atom Atom) bool {
-		return true
-	}
-	onDelete := func(j int, atom Atom) bool {
-		count--
-		if count == i {
-			// Clear pos if atom is deleted.
-			pos = -1
+	s.walkChars(func(pos int, atom Atom, isDeleted bool) bool {
+		if isDeleted {
+			return true
 		}
-		return true
-	}
-	onAtom := func(j int, atom Atom) bool {
 		if count == i {
-			pos = j
-		} else if count > i {
-			// Break when we're sure previous atom wasn't deleted.
+			indexPos = pos
 			return false
 		}
 		count++
 		return true
+	})
+	if indexPos == -1 {
+		return fmt.Errorf("out of bounds")
 	}
-	s := cur.GetString()
-	s.treePosition.walk(onDeletePos, onDelete, onAtom)
-	if pos == -1 {
-		return fmt.Errorf("Out of bounds")
-	}
-	cur.atomID = cur.t.Weave[pos].ID
-	cur.lastKnownPos = pos
+	cur.atomID = cur.t.Weave[indexPos].ID
+	cur.lastKnownPos = indexPos
 	return nil
 }
 
 // Value returns the character pointed by the cursor.
+// Returns an error if cursor is pointing to the string head.
 func (cur *StringCursor) Value() (rune, error) {
 	pos := cur.atomIndex()
 	atom := cur.t.Weave[pos]
@@ -211,7 +235,7 @@ func (cur *StringCursor) Value() (rune, error) {
 	case InsertChar:
 		return v.Char, nil
 	case InsertStr:
-		return unicode.ReplacementChar, fmt.Errorf("Out of bounds")
+		return unicode.ReplacementChar, fmt.Errorf("out of bounds")
 	default:
 		panic("Unexpected atom type")
 	}

--- a/crdt/cursor.go
+++ b/crdt/cursor.go
@@ -1,0 +1,75 @@
+package crdt
+
+import (
+	"fmt"
+)
+
+// Value represents a structure that may be converted to concrete data.
+//
+// Each concrete type has a Snapshot() method with appropriate return type.
+type Value interface {
+	isValue()
+}
+
+// treePosition stores an atom's position for a cursor.
+// The atom is always defined by its ID, but we also store its last known position to
+// speed up searching for it. Since trees are insert-only, the atom can only be at this
+// position or to its right.
+type treePosition struct {
+	t            *CausalTree
+	atomID       AtomID
+	lastKnownPos int
+}
+
+func (p *treePosition) atomIndex() int {
+	size := len(p.t.Weave)
+	for i := p.lastKnownPos; i < size; i++ {
+		if p.t.Weave[i].ID == p.atomID {
+			p.lastKnownPos = i
+			return i
+		}
+	}
+	panic(fmt.Sprintf("atomID %v not found after position %d (weave size: %d)", p.atomID, p.lastKnownPos, size))
+}
+
+// String is a Value representing a sequence of Unicode codepoints.
+type String struct{ treePosition }
+
+func (*String) isValue() {}
+
+// Snapshot returns the string represented by the atom.
+func (s *String) Snapshot() string {
+	i := s.atomIndex()
+
+	var chars []rune
+	var isDeleting bool
+	walkCausalBlock(s.t.Weave[i:], func(atom Atom) bool {
+		switch v := atom.Value.(type) {
+		case Delete:
+			if atom.Cause == s.atomID {
+				// String itself is deleted, interrupt iteration.
+				return false
+			}
+			// A char atom may have multiple Delete children, so we remove it only
+			// once when isDeleting=false.
+			if !isDeleting {
+				isDeleting = true
+				chars = chars[:len(chars)-1]
+			}
+		case InsertChar:
+			isDeleting = false
+			chars = append(chars, v.Char)
+		}
+		return true
+	})
+
+	return string(chars)
+}
+
+func (t *CausalTree) StringValue(atomID AtomID) *String {
+	return &String{treePosition{
+		t:            t,
+		atomID:       atomID,
+		lastKnownPos: t.atomIndex(atomID),
+	}}
+}

--- a/crdt/cursor.go
+++ b/crdt/cursor.go
@@ -2,6 +2,7 @@ package crdt
 
 import (
 	"fmt"
+	"unicode"
 )
 
 // Value represents a structure that may be converted to concrete data.
@@ -32,34 +33,56 @@ func (p *treePosition) atomIndex() int {
 	panic(fmt.Sprintf("atomID %v not found after position %d (weave size: %d)", p.atomID, p.lastKnownPos, size))
 }
 
+func (p *treePosition) walk(onDeletePos, onDelete, onAtom func(j int, atom Atom) bool) {
+	i := p.atomIndex()
+
+	isDeleting := false
+	j := i
+	walkCausalBlock(p.t.Weave[i:], func(atom Atom) bool {
+		j++
+		switch atom.Value.(type) {
+		case Delete:
+			if atom.Cause == p.atomID {
+				// Position itself is deleted, maybe interrupt iteration.
+				return onDeletePos(j, atom)
+			}
+			// Any atom may have multiple consecutive Delete children, so we call onDelete only
+			// once, when isDeleting=false.
+			if !isDeleting {
+				isDeleting = true
+				return onDelete(j, atom)
+			}
+			return true
+		default:
+			isDeleting = false
+			return onAtom(j, atom)
+		}
+	})
+}
+
+// ---- String value
+
 // String is a Value representing a sequence of Unicode codepoints.
 type String struct{ treePosition }
 
 func (*String) isValue() {}
 
 func (s *String) walk(onDeleteChar, onInsertChar func(atom Atom)) {
-	i := s.atomIndex()
-
-	isDeleting := false
-	walkCausalBlock(s.t.Weave[i:], func(atom Atom) bool {
-		switch atom.Value.(type) {
-		case Delete:
-			if atom.Cause == s.atomID {
-				// String itself is deleted, interrupt iteration.
-				return false
-			}
-			// A char atom may have multiple Delete children, so we remove it only
-			// once when isDeleting=false.
-			if !isDeleting {
-				isDeleting = true
-				onDeleteChar(atom)
-			}
-		case InsertChar:
-			isDeleting = false
-			onInsertChar(atom)
-		}
+	onDeletePos := func(j int, atom Atom) bool { return true }
+	onDelete := func(j int, atom Atom) bool {
+		onDeleteChar(atom)
 		return true
-	})
+	}
+	onAtom := func(j int, atom Atom) bool {
+		switch atom.Value.(type) {
+		case InsertChar:
+			onInsertChar(atom)
+			return true
+		default:
+			panic(fmt.Sprintf("Invalid atom value for string: %T", atom.Value))
+		}
+	}
+	s.treePosition.walk(onDeletePos, onDelete, onAtom)
 }
 
 // Snapshot returns the string represented by the atom.
@@ -88,7 +111,113 @@ func (s *String) Len() int {
 	return size
 }
 
-// ----
+// Cursor returns a cursor pointing to the string head.
+func (s *String) Cursor() *StringCursor {
+	return &StringCursor{s.treePosition, s.treePosition.lastKnownPos}
+}
+
+// ---- String cursor
+
+// StringCursor is a mutable tree location, initialized to before the first char.
+//
+// It always points either to the head InsertStr, or to one of InsertChars within the head's
+// causal block.
+type StringCursor struct {
+	treePosition
+
+	// Store the last known position of the string's head, e.g., InsertStr atom.
+	lastKnownHeadPos int
+}
+
+// GetString returns a pointer to the cursor's owner string.
+func (cur *StringCursor) GetString() *String {
+	// Find head.
+	//
+	// Given c0 as the last known position of the pointed-to atom, and c1 its
+	// current position, we know that (c1-c0) atoms were inserted since the last
+	// cursor usage. The head position may be anywhere between s0 (its last known
+	// position) and s0+(c1-c0).
+	//
+	// We search backwards from the end of the range. The first InsertStr atom found
+	// must be the head of the char's string.
+	c0 := cur.lastKnownPos
+	c1 := cur.atomIndex()
+	s0 := cur.lastKnownHeadPos
+	headPos := -1
+	for j := s0 + (c1 - c0); j >= s0; j-- {
+		atom := cur.t.Weave[j]
+		if _, ok := atom.Value.(InsertStr); ok {
+			headPos = j
+			cur.lastKnownHeadPos = j
+			break
+		}
+	}
+	if headPos < 0 {
+		panic(fmt.Sprintf("Invalid weave"))
+	}
+	return &String{
+		treePosition{
+			t:            cur.t,
+			atomID:       cur.t.Weave[headPos].ID,
+			lastKnownPos: headPos,
+		},
+	}
+}
+
+// Index moves the cursor to the given string position.
+func (cur *StringCursor) Index(i int) error {
+	if i < -1 {
+		return fmt.Errorf("Out of bounds")
+	}
+	// Walk the string forward to find the char at position i.
+	pos := -1
+	var count int
+	onDeletePos := func(j int, atom Atom) bool {
+		return true
+	}
+	onDelete := func(j int, atom Atom) bool {
+		count--
+		if count == i {
+			// Clear pos if atom is deleted.
+			pos = -1
+		}
+		return true
+	}
+	onAtom := func(j int, atom Atom) bool {
+		if count == i {
+			pos = j
+		} else if count > i {
+			// Break when we're sure previous atom wasn't deleted.
+			return false
+		}
+		count++
+		return true
+	}
+	s := cur.GetString()
+	s.treePosition.walk(onDeletePos, onDelete, onAtom)
+	if pos == -1 {
+		return fmt.Errorf("Out of bounds")
+	}
+	cur.atomID = cur.t.Weave[pos].ID
+	cur.lastKnownPos = pos
+	return nil
+}
+
+// Value returns the character pointed by the cursor.
+func (cur *StringCursor) Value() (rune, error) {
+	pos := cur.atomIndex()
+	atom := cur.t.Weave[pos]
+	switch v := atom.Value.(type) {
+	case InsertChar:
+		return v.Char, nil
+	case InsertStr:
+		return unicode.ReplacementChar, fmt.Errorf("Out of bounds")
+	default:
+		panic("Unexpected atom type")
+	}
+}
+
+// ---- CausalTree methods
 
 // StringValue returns a wrapper over InsertStr.
 func (t *CausalTree) StringValue(atomID AtomID) (*String, error) {

--- a/crdt/cursor.go
+++ b/crdt/cursor.go
@@ -66,10 +66,15 @@ func (s *String) Snapshot() string {
 	return string(chars)
 }
 
-func (t *CausalTree) StringValue(atomID AtomID) *String {
+func (t *CausalTree) StringValue(atomID AtomID) (*String, error) {
+	i := t.atomIndex(atomID)
+	atom := t.Weave[i]
+	if _, ok := atom.Value.(InsertStr); !ok {
+		return nil, fmt.Errorf("%v is not an InsertStr atom: %T (%v)", atomID, atom, atom)
+	}
 	return &String{treePosition{
 		t:            t,
 		atomID:       atomID,
 		lastKnownPos: t.atomIndex(atomID),
-	}}
+	}}, nil
 }

--- a/crdt/cursor_test.go
+++ b/crdt/cursor_test.go
@@ -149,7 +149,7 @@ func TestStringCursor(t *testing.T) {
 				// Delete string.
 				{op: deleteCharAt, pos: 0},
 			},
-			"crdt",
+			"",
 			crdt.AtomID{0, 0, 2},
 		},
 	}

--- a/crdt/cursor_test.go
+++ b/crdt/cursor_test.go
@@ -20,9 +20,13 @@ func TestString(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
-		want := "crdt"
-		if got := str.Snapshot(); got != want {
-			t.Errorf("str.Snapshot() = %s (!= %s)", got, want)
+		wantStr := "crdt"
+		if got := str.Snapshot(); got != wantStr {
+			t.Errorf("str.Snapshot() = %s (!= %s)", got, wantStr)
+		}
+		wantLen := 4
+		if got := str.Len(); got != wantLen {
+			t.Errorf("str.Len() = %d (!= %d)", got, wantLen)
 		}
 	})
 	t.Run("DeletedChar", func(t *testing.T) {
@@ -41,9 +45,13 @@ func TestString(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
-		want := "cdt"
-		if got := str.Snapshot(); got != want {
-			t.Errorf("str.Snapshot() = %s (!= %s)", got, want)
+		wantStr := "cdt"
+		if got := str.Snapshot(); got != wantStr {
+			t.Errorf("str.Snapshot() = %s (!= %s)", got, wantStr)
+		}
+		wantLen := 3
+		if got := str.Len(); got != wantLen {
+			t.Errorf("str.Len() = %d (!= %d)", got, wantLen)
 		}
 	})
 	t.Run("DoubleDeleteChar", func(t *testing.T) {
@@ -65,9 +73,13 @@ func TestString(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
-		want := "cdt"
-		if got := str.Snapshot(); got != want {
-			t.Errorf("str.Snapshot() = %s (!= %s)", got, want)
+		wantStr := "cdt"
+		if got := str.Snapshot(); got != wantStr {
+			t.Errorf("str.Snapshot() = %s (!= %s)", got, wantStr)
+		}
+		wantLen := 3
+		if got := str.Len(); got != wantLen {
+			t.Errorf("str.Len() = %d (!= %d)", got, wantLen)
 		}
 	})
 }

--- a/crdt/cursor_test.go
+++ b/crdt/cursor_test.go
@@ -15,7 +15,11 @@ func TestString(t *testing.T) {
 			{op: insertChar, char: 'd'},
 			{op: insertChar, char: 't'},
 		})
-		str := trees[0].StringValue(crdt.AtomID{0, 0, 2})
+		str, err := trees[0].StringValue(crdt.AtomID{0, 0, 2})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
 		want := "crdt"
 		if got := str.Snapshot(); got != want {
 			t.Errorf("str.Snapshot() = %s (!= %s)", got, want)
@@ -32,7 +36,11 @@ func TestString(t *testing.T) {
 			// Delete char 'r' in position #2.
 			{op: deleteCharAt, pos: 2},
 		})
-		str := trees[0].StringValue(crdt.AtomID{0, 0, 2})
+		str, err := trees[0].StringValue(crdt.AtomID{0, 0, 2})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
 		want := "cdt"
 		if got := str.Snapshot(); got != want {
 			t.Errorf("str.Snapshot() = %s (!= %s)", got, want)
@@ -46,13 +54,17 @@ func TestString(t *testing.T) {
 			{local: 0, op: insertChar, char: 'd'},
 			{local: 0, op: insertChar, char: 't'},
 
-			// Doubly delete char 'r' in position #2.
+			// Doubly delete char 'r' in position #2 via merge.
 			{local: 0, op: fork, remote: 1},
 			{local: 0, op: deleteCharAt, pos: 2},
 			{local: 1, op: deleteCharAt, pos: 2},
 			{local: 0, op: merge, remote: 1},
 		})
-		str := trees[0].StringValue(crdt.AtomID{0, 0, 2})
+		str, err := trees[0].StringValue(crdt.AtomID{0, 0, 2})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
 		want := "cdt"
 		if got := str.Snapshot(); got != want {
 			t.Errorf("str.Snapshot() = %s (!= %s)", got, want)

--- a/crdt/cursor_test.go
+++ b/crdt/cursor_test.go
@@ -1,0 +1,61 @@
+package crdt_test
+
+import (
+	"testing"
+
+	"github.com/brunokim/causal-tree/crdt"
+)
+
+func TestString(t *testing.T) {
+	t.Run("Snapshot", func(t *testing.T) {
+		trees := testOperations(t, []operation{
+			{op: insertStr},
+			{op: insertChar, char: 'c'},
+			{op: insertChar, char: 'r'},
+			{op: insertChar, char: 'd'},
+			{op: insertChar, char: 't'},
+		})
+		str := trees[0].StringValue(crdt.AtomID{0, 0, 2})
+		want := "crdt"
+		if got := str.Snapshot(); got != want {
+			t.Errorf("str.Snapshot() = %s (!= %s)", got, want)
+		}
+	})
+	t.Run("DeletedChar", func(t *testing.T) {
+		trees := testOperations(t, []operation{
+			{op: insertStr},
+			{op: insertChar, char: 'c'},
+			{op: insertChar, char: 'r'},
+			{op: insertChar, char: 'd'},
+			{op: insertChar, char: 't'},
+
+			// Delete char 'r' in position #2.
+			{op: deleteCharAt, pos: 2},
+		})
+		str := trees[0].StringValue(crdt.AtomID{0, 0, 2})
+		want := "cdt"
+		if got := str.Snapshot(); got != want {
+			t.Errorf("str.Snapshot() = %s (!= %s)", got, want)
+		}
+	})
+	t.Run("DoubleDeleteChar", func(t *testing.T) {
+		trees := testOperations(t, []operation{
+			{local: 0, op: insertStr},
+			{local: 0, op: insertChar, char: 'c'},
+			{local: 0, op: insertChar, char: 'r'},
+			{local: 0, op: insertChar, char: 'd'},
+			{local: 0, op: insertChar, char: 't'},
+
+			// Doubly delete char 'r' in position #2.
+			{local: 0, op: fork, remote: 1},
+			{local: 0, op: deleteCharAt, pos: 2},
+			{local: 1, op: deleteCharAt, pos: 2},
+			{local: 0, op: merge, remote: 1},
+		})
+		str := trees[0].StringValue(crdt.AtomID{0, 0, 2})
+		want := "cdt"
+		if got := str.Snapshot(); got != want {
+			t.Errorf("str.Snapshot() = %s (!= %s)", got, want)
+		}
+	})
+}

--- a/crdt/cursor_test.go
+++ b/crdt/cursor_test.go
@@ -1,6 +1,7 @@
 package crdt_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/brunokim/causal-tree/crdt"
@@ -82,4 +83,137 @@ func TestString(t *testing.T) {
 			t.Errorf("str.Len() = %d (!= %d)", got, wantLen)
 		}
 	})
+}
+
+func TestStringCursor(t *testing.T) {
+	tests := []struct {
+		desc   string
+		ops    []operation
+		value  string
+		atomID crdt.AtomID
+	}{
+		{
+			"only inserts",
+			[]operation{
+				{op: insertStr},
+				{op: insertChar, char: 'c'},
+				{op: insertChar, char: 'r'},
+				{op: insertChar, char: 'd'},
+				{op: insertChar, char: 't'},
+			},
+			"crdt",
+			crdt.AtomID{0, 0, 2},
+		},
+		{
+			"delete str[1]",
+			[]operation{
+				{op: insertStr},
+				{op: insertChar, char: 'c'},
+				{op: insertChar, char: 'r'},
+				{op: insertChar, char: 'd'},
+				{op: insertChar, char: 't'},
+
+				// Delete char 'r'.
+				{op: deleteCharAt, pos: 2},
+			},
+			"cdt",
+			crdt.AtomID{0, 0, 2},
+		},
+		{
+			"delete str[1] twice",
+			[]operation{
+				{local: 0, op: insertStr},
+				{local: 0, op: insertChar, char: 'c'},
+				{local: 0, op: insertChar, char: 'r'},
+				{local: 0, op: insertChar, char: 'd'},
+				{local: 0, op: insertChar, char: 't'},
+
+				// Doubly delete char 'r' in position #2 via merge.
+				{local: 0, op: fork, remote: 1},
+				{local: 0, op: deleteCharAt, pos: 2},
+				{local: 1, op: deleteCharAt, pos: 2},
+				{local: 0, op: merge, remote: 1},
+			},
+			"cdt",
+			crdt.AtomID{0, 0, 2},
+		},
+		{
+			"delete string",
+			[]operation{
+				{op: insertStr},
+				{op: insertChar, char: 'c'},
+				{op: insertChar, char: 'r'},
+				{op: insertChar, char: 'd'},
+				{op: insertChar, char: 't'},
+
+				// Delete string.
+				{op: deleteCharAt, pos: 0},
+			},
+			"crdt",
+			crdt.AtomID{0, 0, 2},
+		},
+	}
+	for _, test := range tests {
+		trees := testOperations(t, test.ops)
+		str, err := trees[0].StringValue(test.atomID)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		t.Run(fmt.Sprintf("OneCursorPerChar/desc=%s", test.desc), func(t *testing.T) {
+			for i, want := range test.value {
+				cur := str.Cursor()
+				cur.Index(i)
+				got, err := cur.Value()
+				if err != nil {
+					t.Fatalf("iteration #%d: err: %v", i, err)
+				}
+				if got != want {
+					t.Errorf("str[%d] = %c (!= %c)", i, got, want)
+				}
+			}
+		})
+		t.Run(fmt.Sprintf("MutableCursorForward/desc=%s", test.desc), func(t *testing.T) {
+			cur := str.Cursor()
+			for i, want := range test.value {
+				cur.Index(i)
+				got, err := cur.Value()
+				if err != nil {
+					t.Fatalf("iteration #%d: err: %v", i, err)
+				}
+				if got != want {
+					t.Errorf("str[%d] = %c (!= %c)", i, got, want)
+				}
+			}
+		})
+		t.Run(fmt.Sprintf("MutableCursorBackward/desc=%s", test.desc), func(t *testing.T) {
+			cur := str.Cursor()
+			chars := []rune(test.value)
+			n := len(chars)
+			for i := n - 1; i >= 0; i-- {
+				cur.Index(i)
+				got, err := cur.Value()
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
+				want := chars[i]
+				if got != want {
+					t.Errorf("str[%d] = %c (!= %c)", i, got, want)
+				}
+			}
+		})
+		t.Run(fmt.Sprintf("Errors/desc=%s", test.desc), func(t *testing.T) {
+			cur := str.Cursor()
+			chars := []rune(test.value)
+			n := len(chars)
+			if err := cur.Index(n); err == nil {
+				t.Errorf("cur.Index(%d): want err, got nil", n)
+			}
+			if err := cur.Index(-2); err == nil {
+				t.Errorf("cur.Index(%d): want err, got nil", -2)
+			}
+			if got, err := cur.Value(); err == nil {
+				t.Errorf("want err, got nil (char: %c)", got)
+			}
+		})
+	}
 }

--- a/crdt/example_ctree_test.go
+++ b/crdt/example_ctree_test.go
@@ -66,7 +66,6 @@ func ExampleCausalTree_overlap() {
 	// Output: dreser
 }
 
-//
 func ExampleCausalTree_ViewAt() {
 	s0 := crdt.NewCausalTree() // S0 @ T1
 	s0.InsertChar('a')         // S0 @ T2


### PR DESCRIPTION
# What

Start implementation of new API with better ergonomics for library users.

Methods created:

- `(*CausalTree).StringValue(AtomID) *String`: creates a String from a given atom ID, that must be an `InsertStr` atom;
- `(*String).IsDeleted() bool`: returns whether the string is deleted;
- `(*String).Snapshot() string`: returns the contents of the string, or "" if it's deleted;
- `(*String).Len() string`: returns the length of the string in codepoints, or 0 if it's deleted;
- `(*String).Cursor() *StringCursor`: returns a cursor pointing to the string's head;
- `(*StringCursor).Index(i int) error`: moves the cursor to the i-th char of the string;
- `(*StringCursor) Value() (rune, error)`: returns the char pointed by the cursor.

# Why

The current cursor field in the CausalTree is not sufficient to represent deeply-nested structures, only individual characters in a string. This API will provide not only cursors to iterate, query and update each container stored in the tree, as well as the objects themselves. We believe this is a more ergonomic and higher-level view for library users, referencing semantic objects instead of raw atoms to manipulate.

# Notes

This implemetation proposes a new atom walker with `walkCausalBlock2`, that expects a function with the signature

```
func(pos int, atom Atom, isDeleted bool) bool
```

The function receives the atom position in the weave, the atom itself, and whether it's deleted. It skips over any `Delete` atoms, which are just used to fill the `isDeleted` param. The function must return whether iteration should continue or break. Either way, it stops when finding the end of the causal block of the first atom (which is included in the iteration).

# Tests

Tests were limited to unit tests that achieve partial coverage for the implementation. They are still missing for cases where there should be two or more strings in the same causal tree, that is, where'd actually reach the end of the causal block before the end of the weave.

![Captura de tela de 2023-06-28 15-08-46](https://github.com/crdteam/causal-tree/assets/693510/8d7e5325-f8bc-4c47-8b2f-b3804cfc0626)
https://output.circle-artifacts.com/output/job/e7ede96b-44c4-4e3f-87cc-26728b6dc535/artifacts/0/tmp/test-artifacts/coverage.html#file1

I believe the most bang for the buck is found in writing new property tests, which I'll do once we implement mutable methods (`(*StringCursor).Insert`, `(*StringCursor).Delete`, `(*String).Delete`).